### PR TITLE
Bumped the version to 0.3.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <package>
 
   <name>axis_camera</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>
     Python ROS drivers for accessing an Axis camera's MJPG
     stream. Also provides control for PTZ cameras.


### PR DESCRIPTION
This is the easiest fix for selecting our package over the ROS-bundled
one. This might be a bit hacky, but bumping the version does make sense
anyway.
